### PR TITLE
Fix filename normalization without extension

### DIFF
--- a/src/utils/data-normalizer.ts
+++ b/src/utils/data-normalizer.ts
@@ -76,8 +76,9 @@ export class DataNormalizer {
    * Normalize file name for comparison
    */
   public static normalizeFileName(fileName: string): string {
-    // Remove extension and normalize
-    const nameWithoutExt = fileName.substring(0, fileName.lastIndexOf('.'));
+    // Remove extension and normalize. If no extension exists, use full name
+    const lastDot = fileName.lastIndexOf('.');
+    const nameWithoutExt = lastDot === -1 ? fileName : fileName.substring(0, lastDot);
     return this.normalizeText(nameWithoutExt);
   }
 


### PR DESCRIPTION
## Summary
- handle filenames without an extension when normalizing

## Testing
- `npm run lint` *(fails: Cannot find package '/workspace/deliverables-qc/node_modules/@eslint/js/index.js')*

------
https://chatgpt.com/codex/tasks/task_b_68835ea3716c8323b5b8acc7872799f1